### PR TITLE
Add Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 node_modules/*
 build/*
 package-lock.json
+
+# Ignore directories
+**/.vs
+**/bin
+**/obj
+**/node_modules
+
+# Ignore files
+*.bak

--- a/addon/wolfcrypt/h/pbkdf2.h
+++ b/addon/wolfcrypt/h/pbkdf2.h
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 #include <napi.h>
-#include "wolfssl/options.h"
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,19 +15,41 @@
             "addon/wolfcrypt/pkcs12.cpp",
             "addon/wolfcrypt/random.cpp"
         ],
-        'include_dirs': [
+        "include_dirs": [
             "<!@(node -p \"require('node-addon-api').include\")"
         ],
-        'libraries': [
-            "/usr/local/lib/libwolfssl.so"
+        "libraries": [],
+        "dependencies": [
+            "<!(node -p \"require('node-addon-api').gyp\")"
         ],
-        'dependencies': [
-            "<!(node -p \"require('node-addon-api').gyp\")",
+        "defines": [ "NAPI_DISABLE_C_EXCEPTIONS" ],
+        "conditions": [
+            ['OS=="linux"', {
+                "libraries": [
+                    "/usr/local/lib/libwolfssl.so"
+                ]
+            }],
+            ['OS=="win"', {
+                "defines": [ "WOLFSSL_USER_SETTINGS" ],
+                "libraries": [
+                    "<!(powershell -command \"if ($env:WOLFSSL_LIB_PATH) { echo $env:WOLFSSL_LIB_PATH } else { echo 'C:/workspace/wolfssl/DLL Release/x64' }\")/wolfssl.lib",
+                    "ws2_32.lib",
+                    "crypt32.lib",
+                    "advapi32.lib",
+                    "user32.lib",
+                    "kernel32.lib"
+                ],
+                "include_dirs": [
+                    "<!(powershell -command \"if ($env:WOLFSSL_INCLUDE_PATH) { echo $env:WOLFSSL_INCLUDE_PATH } else { echo 'C:/workspace/wolfssl' }\")",
+                    "<!(powershell -command \"if ($env:WOLFSSL_USER_SETTINGS_PATH) { echo $env:WOLFSSL_USER_SETTINGS_PATH } else { echo 'C:/workspace/wolfssl/IDE/WIN' }\")"
+                ]
+            }],
+
         ],
         'defines': ['NAPI_DISABLE_C_EXCEPTIONS'],
         'msvs_settings': {
             'VCCLCompilerTool': {
-                'ExceptionHandling': '1',    
+                'ExceptionHandling': '1',
                 'AdditionalOptions': ['/EHsc']
             }
         }

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,8 @@
+# wolfcrypt_nodejs lib
+
+The enclosed [user_settings.h](./user_settings.h) was used to build wolfSSL when using Visual Studio 2022.
+
+Place that file in `<wolfssl>\IDE\WIN`.
+
+See PR [#8090](https://github.com/wolfSSL/wolfssl/pull/8090) and
+the [VS2022 project file](https://github.com/gojimmypi/wolfssl/blob/pr-visual-studio-2022/wolfssl-VS2022.vcxproj).

--- a/lib/user_settings.h
+++ b/lib/user_settings.h
@@ -1,0 +1,151 @@
+#ifndef _WIN_USER_SETTINGS_H_
+#define _WIN_USER_SETTINGS_H_
+
+/* Verify this is Windows */
+#ifndef _WIN32
+#error This user_settings.h header is only designed for Windows
+#endif
+
+#define USE_WOLFSSL_IO
+#define HAVE_AESGCM
+#define WOLFSSL_TLS13
+#define HAVE_HKDF
+#define HAVE_FFDHE_4096
+#define WC_RSA_PSS
+#define WOLFSSL_DTLS
+#define WOLFSSL_DTLS13
+#define WOLFSSL_SEND_HRR_COOKIE
+#define WOLFSSL_DTLS_CID
+
+/* npm */
+#define NPM_WOLFCRYPT
+#ifdef NPM_WOLFCRYPT
+    /* Optional debug */
+    /* #define DEBUG_WOLFSSL */
+
+    /* Optional RNG */
+    /* #define WC_RNG_SEED_CB */
+
+    #define HAVE_PKCS7
+    #define HAVE_AES_KEYWRAP
+    #define WOLFSSL_AES_DIRECT
+    #define HAVE_X963_KDF
+    #define WOLFSSL_SHA224
+    #define WOLFSSL_KEY_GEN
+    #define HAVE_ECC
+    #define ECC_MAX_BITS 521
+    #define WC_ECC256
+    #define WC_ECC384
+    #define WC_ECC521
+    #define HAVE_ECC_ENCRYPT
+    #define WOLFSSL_UINT128_T_DEFINED
+    #define WOLFSSL_SHA512
+    #define WOLFSSL_SHA384
+    #define WOLFSSL_SHA3
+
+    #define NO_OLD_RNGNAME
+    #define TFM_TIMING_RESISTANT
+    #define ECC_TIMING_RESISTANT
+    #define WC_RSA_BLINDING
+    #define TFM_ECC256
+    #define ECC_SHAMIR
+    #define ECC_MIN_KEY_SZ 224
+    #define HAVE_ECC_BRAINPOOL
+    #define HAVE_CURVE25519
+    #define FP_ECC
+    #define HAVE_ECC_ENCRYPT
+    #define WOLFCRYPT_HAVE_ECCSI
+    #define WOLFSSL_CUSTOM_CURVES
+#endif
+
+/* Configurations */
+#if defined(HAVE_FIPS)
+    /* FIPS */
+    #define OPENSSL_EXTRA
+    #define HAVE_THREAD_LS
+    #define WOLFSSL_KEY_GEN
+    #define HAVE_HASHDRBG
+    #define WOLFSSL_SHA384
+    #define WOLFSSL_SHA512
+    #define NO_PSK
+    #define NO_RC4
+    #define NO_DSA
+    #define NO_MD4
+
+    #define GCM_NONCE_MID_SZ 12
+#else
+    /* Enables blinding mode, to prevent timing attacks */
+    #define WC_RSA_BLINDING
+    #define NO_MULTIBYTE_PRINT
+
+    #define HAVE_CRL
+    #define HAVE_CRL_MONITOR
+
+    #if defined(WOLFSSL_LIB)
+        /* The lib */
+        #define OPENSSL_EXTRA
+        #define WOLFSSL_RIPEMD
+        #define NO_PSK
+        #define HAVE_EXTENDED_MASTER
+        #define WOLFSSL_SNIFFER
+        #define HAVE_SECURE_RENEGOTIATION
+
+        #define HAVE_AESGCM
+        #define WOLFSSL_AESGCM_STREAM
+        #define WOLFSSL_SHA384
+        #define WOLFSSL_SHA512
+
+        #define HAVE_SUPPORTED_CURVES
+        #define HAVE_TLS_EXTENSIONS
+
+        #define HAVE_ECC
+        #define ECC_SHAMIR
+        #define ECC_TIMING_RESISTANT
+
+        #define WOLFSSL_SP_X86_64
+        #define SP_INT_BITS  4096
+
+        /* Optional Performance Speedups */
+        #if 0
+            /* AESNI on x64 */
+            #ifdef _WIN64
+                #define HAVE_INTEL_RDSEED
+                #define WOLFSSL_AESNI
+                #define HAVE_INTEL_AVX1
+                #if 0
+                    #define HAVE_INTEL_AVX2
+                #endif
+
+                #define USE_INTEL_CHACHA_SPEEDUP
+                #define USE_INTEL_POLY1305_SPEEDUP
+            #endif
+
+            /* Single Precision Support for RSA/DH 1024/2048/3072 and
+             * ECC P-256/P-384 */
+            #define WOLFSSL_SP
+            #define WOLFSSL_HAVE_SP_ECC
+            #define WOLFSSL_HAVE_SP_DH
+            #define WOLFSSL_HAVE_SP_RSA
+
+            #ifdef _WIN64
+                /* Old versions of MASM compiler do not recognize newer
+                 * instructions. */
+                #if 0
+                    #define NO_AVX2_SUPPORT
+                    #define NO_MOVBE_SUPPORT
+                #endif
+                #define WOLFSSL_SP_ASM
+                #define WOLFSSL_SP_X86_64_ASM
+            #endif
+        #endif
+    #else
+        /* The servers and clients */
+        #define OPENSSL_EXTRA
+        #define NO_PSK
+    #endif
+#endif /* HAVE_FIPS */
+
+
+
+
+#endif /* _WIN_USER_SETTINGS_H_ */

--- a/my_test.ps1
+++ b/my_test.ps1
@@ -1,0 +1,5 @@
+npm run clean
+node-gyp clean
+node-gyp rebuild
+npm i
+npm run test

--- a/setup_env.bat
+++ b/setup_env.bat
@@ -1,0 +1,2 @@
+@echo "Running .\setup_env.ps1 and staying in the powershell environment..."
+powershell -NoExit  -ExecutionPolicy Bypass -File .\setup_env.ps1

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -1,0 +1,87 @@
+$ErrorActionPreference = "Stop"
+
+# Predefined Community, Professional, Enterprise versions of Visual Studio 2022
+$vsPathCommunity = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe"
+$vsPathProfessional = "C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\devenv.exe"
+$vsPathEnterprise = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe"
+
+if (Test-Path "C:/workspace/wolfssl-$env:USERNAME") {
+    $env:WOLFSSL_ROOT = "C:/workspace/wolfssl-$env:USERNAME"
+    $env:PATH += ";$env:WOLFSSL_ROOT\DLL Release\x64"
+
+    Write-Output "Found wolfSSL at $env:WOLFSSL_ROOT"
+    $env:WOLFSSL_LIB_PATH           = "$env:WOLFSSL_ROOT/DLL Release/x64"
+    $env:WOLFSSL_INCLUDE_PATH       = "$env:WOLFSSL_ROOT"
+    $env:WOLFSSL_USER_SETTINGS_PATH = "$env:WOLFSSL_ROOT/IDE/WIN"
+
+} elseif (Test-Path "C:/workspace/wolfssl") {
+    $env:WOLFSSL_ROOT = "C:/workspace/wolfssl"
+    $env:PATH += ";$env:WOLFSSL_ROOT\DLL Release\x64"
+
+    Write-Output "Found wolfSSL at $env:WOLFSSL_ROOT"
+    $env:WOLFSSL_LIB_PATH           = "$env:WOLFSSL_ROOT/DLL Release/x64"
+    $env:WOLFSSL_INCLUDE_PATH       = "$env:WOLFSSL_ROOT"
+    $env:WOLFSSL_USER_SETTINGS_PATH = "$env:WOLFSSL_ROOT/IDE/WIN"
+
+} else {
+    Write-Output "Could not find wolfSSL source directory."
+}
+
+
+Write-Output "WOLFSSL_LIB_PATH:           $($env:WOLFSSL_LIB_PATH)"
+Write-Output "WOLFSSL_INCLUDE_PATH:       $($env:WOLFSSL_INCLUDE_PATH)"
+Write-Output "WOLFSSL_USER_SETTINGS_PATH: $($env:WOLFSSL_USER_SETTINGS_PATH)"
+
+fnm env --use-on-cd | Out-String | Invoke-Expression
+fnm use --install-if-missing 20
+node -v # should print `v20.18.0`
+npx -v # should print `10.8.2`
+
+# Launch VS2022 from the same shell:
+# Check if the file exists
+if (Test-Path $vsPathEnterprise) {
+    # Run the file
+    Write-Output "Launching Visual Studio 2022 Enterprise at: $vsPathEnterprise"
+    Start-Process $vsPathEnterprise
+
+} elseif (Test-Path $vsPathProfessional) {
+    # Run the file
+    Write-Output "Launching Visual Studio 2022 Professional at: $vsPathProfessional"
+    Start-Process $vsPathProfessional
+
+} elseif (Test-Path $vsPathCommunity) {
+    # Run the file
+    Write-Output "Launching Visual Studio 2022 Community at: $vsPathCommunity"
+    Start-Process $vsPathCommunity
+
+} else {
+    Write-Output "Visual Studio 2022 executable not found."
+}
+
+Write-Output "Clean..."
+npm run clean
+npx node-gyp clean
+
+Write-Output "Rebuild..."
+npx node-gyp rebuild
+
+Write-Output "Install..."
+npm install
+
+Write-Output "Test..."
+npm run test
+
+
+# One final check if the user_settings.h match
+$File1 = Get-Content "$($env:WOLFSSL_USER_SETTINGS_PATH)/user_settings.h"
+$File2 = Get-Content "./lib/user_settings.h"
+
+$diff = Compare-Object $File1 $File2
+
+if ($diff) {
+    Write-Host "Warning: "
+    Write-Host "./lib/user_settings.h does not match"
+    Write-Host "$($env:WOLFSSL_USER_SETTINGS_PATH)/user_settings.h"
+} else {
+    Write-Host "Confirmed reference ./lib/user_settings.h matches wolfSSL source."
+}

--- a/test.js
+++ b/test.js
@@ -23,6 +23,8 @@ const tests = require( './tests' );
 (async function() {
   for ( const key of Object.keys( tests ) )
   {
+    console.log("Running test: ", key)
     await tests[key]()
+    console.log("")
   }
 })()


### PR DESCRIPTION

This PR adds Windows support for the NodeJS/NPM wolfCrypt module.

See the updated `binding.gyp` for conditional OS checking.

The enclosed `README.md` contains details on useage in the new `Visual Studio` section.

See the new `wolfssl-VS2022.vcxproj` project file added in https://github.com/wolfSSL/wolfssl/pull/8090

There are also new environment setup scripts `setup_env.bat` and `setup_env.ps1`.

Minor modifications were needed to the `IDE/Win` [user_settings.h](https://github.com/wolfSSL/wolfssl/blob/master/IDE/WIN/user_settings.h) so a new reference `user_settings.h` file can be found in the new `./lib` directory.
